### PR TITLE
[Azoth OTRoid] Fixed OTRv3 support.

### DIFF
--- a/src/plugins/azoth/plugins/otroid/otroid.cpp
+++ b/src/plugins/azoth/plugins/otroid/otroid.cpp
@@ -222,11 +222,16 @@ namespace OTRoid
 		otrl_privkey_read (UserState_, GetOTRFilename ("privkey"));
 		otrl_privkey_read_fingerprints (UserState_,
 				GetOTRFilename ("fingerprints"), NULL, NULL);
+#if OTRL_VERSION_MAJOR >= 4
+		otrl_instag_read (UserState_, GetOTRFilename ("instags"));
+#endif
 
 		memset (&OtrOps_, 0, sizeof (OtrOps_));
 		OtrOps_.policy = [] (void*, ConnContext*) { return OtrlPolicy { OTRL_POLICY_DEFAULT }; };
 		OtrOps_.create_privkey = [] (void *opData, const char *accName, const char *proto)
 				{ static_cast<Plugin*> (opData)->CreatePrivkey (accName, proto); };
+		OtrOps_.create_instag = [] (void *opData, const char *accName, const char *proto)
+				{ static_cast<Plugin*> (opData)->CreateInstag (accName, proto); };
 		OtrOps_.is_logged_in = &OTR::IsLoggedIn;
 		OtrOps_.inject_message = &OTR::InjectMessage;
 		OtrOps_.update_context_list = [] (void*) {};
@@ -474,6 +479,11 @@ namespace OTRoid
 	}
 
 #if OTRL_VERSION_MAJOR >= 4
+	void Plugin::CreateInstag (const char *accName, const char *proto)
+	{
+		otrl_instag_generate (UserState_, GetOTRFilename ("instags"), accName, proto);
+	}
+
 	void Plugin::SetPollTimerInterval (unsigned int seconds)
 	{
 		if (PollTimer_->isActive ())
@@ -731,16 +741,7 @@ namespace OTRoid
 			CreatePrivkey (accId.constData (), protoId.constData());
 
 		std::shared_ptr<char> msg (otrl_proto_default_query_msg (accId.constData (),
-#if OTRL_VERSION_MAJOR >= 4
-					OTRL_POLICY_ALLOW_V2), free);
-		// Yes, this is a malicious hack. And in the bright future
-		// (OTRL_POLICY_ALLOW_V3 | OTRL_POLICY_ALLOW_V2) or OTRL_POLICY_DEFAULT
-		// should be used. But for now this is only possible solution for fixing
-		// the problem of initialization of private conversation when both sides
-		// use libotr 4.0.x.
-#else
 					OTRL_POLICY_DEFAULT), free);
-#endif
 		InjectMsg (entry, QString::fromUtf8 (msg.get ()), true, IMessage::DOut);
 	}
 

--- a/src/plugins/azoth/plugins/otroid/otroid.h
+++ b/src/plugins/azoth/plugins/otroid/otroid.h
@@ -106,6 +106,7 @@ namespace OTRoid
 		QString GetVisibleEntryName (const QString& accId, const QString& entryId);
 
 		void CreatePrivkey (const char*, const char*);
+		void CreateInstag (const char*, const char*);
 
 #if OTRL_VERSION_MAJOR >= 4
 		void SetPollTimerInterval (unsigned int seconds);


### PR DESCRIPTION
Added limited support of instance tags. Previous temporary solution is not
needed anymore. (Affects only build with libotr 4.x.)
