### PR TITLE
[DEADLYRICS] Fixed crash with fast track changing in LMP.

### DIFF
--- a/src/plugins/deadlyrics/concretesite.cpp
+++ b/src/plugins/deadlyrics/concretesite.cpp
@@ -244,10 +244,10 @@ namespace DeadLyrics
 	void ConcreteSite::handleReplyFinished ()
 	{
 		auto reply = qobject_cast<QNetworkReply*> (sender ());
+		const auto& data = reply->readAll ();
 		reply->deleteLater ();
 		deleteLater ();
 
-		const auto& data = reply->readAll ();
 #ifdef QT_DEBUG
 		qDebug () << Q_FUNC_INFO
 				<< "got from"


### PR DESCRIPTION
Fix of crash in QNetworkReplyImplPrivate::appendDownstreamData -> bad QIODevice
