### PR TITLE
Be a bit more lenient in .desktop file parsing.

### DIFF
--- a/src/util/xdg/desktopparser.cpp
+++ b/src/util/xdg/desktopparser.cpp
@@ -113,8 +113,8 @@ namespace XDG
 
 				KeyValSep_ %= *(qi::lit (' ')) >> '=' >> *(qi::lit (' '));
 
-				LineValSingle_ %= qi::lexeme [+((qi::lit ("\\;") | (qi::char_ - ';' - '\r' - '\n')))];
-				LineVal_ %= +(LineValSingle_ >> ';') | LineValSingle_;
+				LineValSingle_ %= qi::lexeme [*((qi::lit ("\\;") | (qi::char_ - ';' - '\r' - '\n')))];
+				LineVal_ %= LineValSingle_ >> *(qi::lit(';') >> LineValSingle_) >> -(qi::lit(';'));
 
 				Line_ %= qi::lexeme [+(qi::char_ ("a-zA-Z0-9-"))] >>
 						-Lang_ >>


### PR DESCRIPTION
Please note that I have *not* tested this fix on LeechCraft itself!
Thus, please treat this as a review request.
I have also not used boost::spirit prior to making these changes.

This commit changes two things:
1) It allows for empty values, e.g. "key=". I'm not sure whether this is
allowed or not according to the desktop entry standard, as it's not a
very clearly written standard... but my personal philosophy is to be
forgiving while reading files, and conservative while writing them.
Keys with empty values will still show up, with the empty string as the
value. I'm not sure whether that's OK or not in LeechCraft.

2) It allows for omitting the semicolon after a list/array value, which
the standard demands:
"The multiple values should be separated by a semicolon and the value of
the key may be *optionally* terminated by a semicolon." (Emphasis mine.)

Fix 1 is required for crashplan.desktop, knapshot.desktop, panoramagui.desktop
among others on my system.
Fix 2 is required for firefox.desktop on Ubuntu, baobob.desktop (GNOME
Disk Usage Analyzer), playonlinux.desktop among others.