### PR TITLE
Use more common standard path for cmake files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,7 +249,7 @@ configure_file (FindLeechCraft.cmake.in FindLeechCraft${LC_LIBSUFFIX}.cmake @ONL
 install (FILES
 	${CMAKE_CURRENT_BINARY_DIR}/FindLeechCraft${LC_LIBSUFFIX}.cmake
 	CommonLCSetup.cmake
-	DESTINATION ${LC_SHARE_DEST}/cmake/)
+	DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/leechcraft)
 
 if (APPLE AND NOT USE_UNIX_LAYOUT)
 	configure_file (Info.plist.in Info.plist)


### PR DESCRIPTION
 The current version is also a valid search path

https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure

so feel free to keep it if preferred.